### PR TITLE
Fixing a security issue for VotePost

### DIFF
--- a/app/models/vote_post.rb
+++ b/app/models/vote_post.rb
@@ -67,6 +67,9 @@ class VotePost < ActiveRecord::Base
       unless vote_option_ids.uniq.count == vote_option_ids.count
         errors.add(:vote_option_ids, I18n.t('vote_post.same_option_twice'))
       end
+      unless (vote_option_ids.map(&:to_i) - vote.vote_option_ids).empty?
+        errors.add(:vote_option_ids, I18n.t('vote_post.unallowed_options'))
+      end
     else
       errors.add(:vote_option_ids, I18n.t('vote_post.no_option_selected'))
     end

--- a/config/locales/views/vote_posts.sv.yml
+++ b/config/locales/views/vote_posts.sv.yml
@@ -7,3 +7,4 @@ sv:
     same_option_twice: "varje alternativ kan väljas max en gång"
     too_many_options: "för många alternativ valda"
     vote_closed: "Voteringen är tyvärr stängd"
+    unallowed_options: "alternativet tillhör ej denna votering"

--- a/spec/factories/votes.rb
+++ b/spec/factories/votes.rb
@@ -2,14 +2,15 @@ FactoryGirl.define do
   factory :vote do
     title
     open false
+    choices 1
 
     trait :with_options do
-      transient do
-        option_count 3
-      end
-
-      after(:create) do |vote, evaluator|
-        create_list(:vote_option, evaluator.option_count, vote: vote)
+      vote_options do |o|
+        arr = []
+        o.choices.times do
+          arr << o.association(:vote_option, strategy: @build_strategy.class)
+        end
+        arr
       end
     end
   end

--- a/spec/models/vote_post_spec.rb
+++ b/spec/models/vote_post_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe VotePost, type: :model do
         vote_post.vote_option_ids = [1, 2, 3]
         vote_post.valid?
 
-        vote_post.errors[:vote_option_ids].should be_empty
+        vote_post.errors[:vote_option_ids].should_not include(I18n.t('vote_post.too_many_options'))
       end
 
       it 'has less than maximum amount' do
@@ -97,7 +97,7 @@ RSpec.describe VotePost, type: :model do
         vote_post.vote_option_ids = [1, 2]
         vote_post.valid?
 
-        vote_post.errors[:vote_option_ids].should be_empty
+        vote_post.errors[:vote_option_ids].should_not include(I18n.t('vote_post.no_option_selected'))
       end
 
       it 'has no options' do
@@ -125,6 +125,17 @@ RSpec.describe VotePost, type: :model do
         vote_post.valid?
 
         vote_post.errors[:vote_option_ids].should include(I18n.t('vote_post.same_option_twice'))
+      end
+
+      it 'does not allow vote options not belonging to vote' do
+        vote = build_stubbed(:vote, :with_options, choices: 3)
+        vote.vote_options.first.id.should > 1000
+
+        vote_post = build(:vote_post, vote: vote)
+        vote_post.vote_option_ids = [1, vote.vote_options.first.id]
+        vote_post.valid?
+
+        vote_post.errors[:vote_option_ids].should include(I18n.t('vote_post.unallowed_options'))
       end
     end
   end


### PR DESCRIPTION
Adds a validation to VotePost that checks if the submitted VoteOptions belong to the associated Vote