### PR TITLE
SSL endpoint: adding way to confirm LetsEncrypt

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -11,4 +11,8 @@ class StaticPagesController < ApplicationController
   def index
     @start_page = StartPage.new
   end
+
+  def lets_encrypt
+    render text: ENV['LETSENCRYPT_TOKEN']
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -9,7 +9,7 @@ class Ability
     can :read, News
     can [:mail, :read], Contact, public: true
     can [:new, :create, :read], Faq
-    can [:index, :about, :cookies_information], :static_pages
+    can [:index, :about, :cookies_information, :lets_encrypt], :static_pages
 
     # Abilities all signed in users get
     if user.id.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Fsek::Application.routes.draw do
 
   get :cookies_information, controller: :static_pages, as: :cookies, path: :cookies
   get :about, controller: :static_pages, path: :om
+  get :lets_encrypt, controller: :static_pages, path: '.well-known/acme-challenge/:key'
 
   # User-related routes
   devise_for :users, skip: [:sessions, :registrations], controllers: {registrations: "registrations"}

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -31,4 +31,15 @@ RSpec.describe StaticPagesController, type: :controller do
       assigns(:start_page).class.should eq(StartPage)
     end
   end
+
+  describe 'GET #lets_encrypt' do
+    it 'renders set text' do
+      token = 'awsdawsdwasdwasd6122awsdawsdawsd3737'
+      ENV['LETSENCRYPT_TOKEN'] = token
+      get(:lets_encrypt, key: 'aa')
+
+      response.status.should eq(200)
+      response.body.should eq(token)
+    end
+  end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -12,11 +12,10 @@ RSpec.describe Ability do
     Notice.new => { no: standard },
     Permission.new => { yes: [], no: standard }
   }
-  
+
   let(:signed) { build_stubbed(:user) }
   subject(:signed_ability) { Ability.new(signed) }
 
-  
   describe 'Signed in' do
     ab_signed.each do |obj, value|
       if value[:yes].present?


### PR DESCRIPTION
Sets up a static page where cerificate is confirmed by changing an enironment
variable on Heroku.
The LetsEncrypt script is then run locally to receive certificates which can
then be added through the Heroku CLI.