### PR TITLE
Vote status, agenda connection and reset vote function

### DIFF
--- a/app/assets/javascripts/footer.js
+++ b/app/assets/javascripts/footer.js
@@ -5,7 +5,7 @@ bottom = function () {
     var footerTop = $('#copyright').position().top + footerHeight;
 
     if (footerTop < docHeight) {
-        $('#copyright').css('margin-top', 5 + (docHeight - footerTop) + 'px');
+        $('#copyright').css('margin-top', 2 + (docHeight - footerTop) + 'px');
     }
 };
 

--- a/app/controllers/vote_posts_controller.rb
+++ b/app/controllers/vote_posts_controller.rb
@@ -3,7 +3,7 @@ class VotePostsController < ApplicationController
 
   def new
     @vote = Vote.find(params[:vote_id])
-    if !@vote.open
+    if !@vote.open?
       redirect_to votes_path, alert: I18n.t('vote.is_closed')
     else
       @vote_post = VotePost.new

--- a/app/helpers/agendas_helper.rb
+++ b/app/helpers/agendas_helper.rb
@@ -17,7 +17,7 @@ module AgendasHelper
             method: :patch, remote: true)
   end
 
-  def status_str(state)
+  def agenda_status_str(state)
     if state == Agenda::CURRENT
       Agenda.human_attribute_name('current')
     elsif state == Agenda::FUTURE
@@ -29,7 +29,7 @@ module AgendasHelper
     end
   end
 
-  def status_collection
+  def agenda_status_collection
     [[Agenda.human_attribute_name('future'), Agenda::FUTURE],
      [Agenda.human_attribute_name('current'), Agenda::CURRENT],
      [Agenda.human_attribute_name('closed'), Agenda::CLOSED]]

--- a/app/helpers/vote_user_helper.rb
+++ b/app/helpers/vote_user_helper.rb
@@ -32,4 +32,10 @@ module VoteUserHelper
       end
     end
   end
+
+  def user_filter
+    [[Audit.human_attribute_name('User'), 'User'],
+     [Audit.human_attribute_name('VotePost'), 'VotePost'],
+     [Audit.human_attribute_name('Adjustment'), 'Adjustment']]
+  end
 end

--- a/app/helpers/votes_helper.rb
+++ b/app/helpers/votes_helper.rb
@@ -102,15 +102,15 @@ module VotesHelper
     end
   end
 
-  def vote_state_link(vote)
+  def vote_state_link(vote, type: nil)
     if vote.present?
       if vote.open?
-        link_to(t('vote.do_close'), close_admin_vote_path(vote), method: :patch)
+        link_to(t('vote.do_close'), close_admin_vote_path(vote), method: :patch, class: type)
       elsif vote.closed?
-        link_to(t('vote.do_open'), open_admin_vote_path(vote), method: :patch, data:
+        link_to(t('vote.do_open'), open_admin_vote_path(vote), method: :patch, class: type, data:
                 { confirm: t('vote.reopen') })
       else
-        link_to(t('vote.do_open'), open_admin_vote_path(vote), method: :patch)
+        link_to(t('vote.do_open'), open_admin_vote_path(vote), method: :patch, class: type)
       end
     end
   end

--- a/app/helpers/votes_helper.rb
+++ b/app/helpers/votes_helper.rb
@@ -20,40 +20,45 @@ module VotesHelper
       val = split_presence(value)
     when 'votecode'
       val = split_votecode(value)
-    when 'open'
-      val = split_open(value)
+    when 'status'
+      val = split_status(value)
     when 'title'
       val = split_votecode(value)
+    when 'present_users'
+      val = split_present_users(value)
     else
       val = value.to_s
     end
 
-    unless val.blank?
+    if val.present?
       content = model.human_attribute_name(key) + ': ' + val.to_s
-      content_tag(:p, content)
+    elsif key == 'reset'
+      content = model.human_attribute_name(key)
     end
+
+    content_tag(:p, content)
   end
 
   def split_votecode(value)
     if value.is_a?(Array) && value.size == 2
-      return ((value.first.nil? ? t('log.missing') : value.first.to_s) + t('log.to') +
-              (value.last.nil? ? t('log.missing') : value.last.to_s))
+      ((value.first.nil? ? t('log.missing') : value.first.to_s) + t('log.to') +
+       (value.last.nil? ? t('log.missing') : value.last.to_s))
     else
-      return value.nil? ? t('log.missing') : value
+      value.nil? ? t('log.missing') : value
     end
   end
 
   def split_array(value)
     unless value.is_a?(Array) && value.first.nil?
-      return value.to_s
+      value.to_s
     end
   end
 
   def split_presence(value)
     if value.is_a?(Array) && value.size == 2 && value.first != value.last
-      return presence_string(value.last)
+      presence_string(value.last)
     else
-      return yes_no(value)
+      yes_no(value)
     end
   end
 
@@ -65,38 +70,47 @@ module VotesHelper
     end
   end
 
-  def split_open(value)
-    if value.is_a?(Array) && value.size == 2 && value.first != value.last
-      return open_closed_string(value.last)
-    else
-      return yes_no(value)
-    end
-  end
-
-  def split_agenda(value)
+  def split_status(value)
     if value.is_a?(Array) && value.size == 2
-      '§' + Agenda.find(value.first).order + t('log.to') + '§' + Agenda.find(value.last).order
+      vote_status_str(value.first) + t('log.to') + vote_status_str(value.last)
     else
       value.to_s
     end
   end
 
-  def open_closed_string(value)
-    if value
-      t('vote.made_open')
+  def split_agenda(value)
+    if value.is_a?(Array) && value.size == 2
+      agenda_log_str(value.first) + t('log.to') + agenda_log_str(value.last)
     else
-      t('vote.made_closed')
+      value.to_s
+    end
+  end
+
+  def agenda_log_str(value)
+    if value.present?
+      '§' + Agenda.find(value).order
+    else
+      t('log.missing')
+    end
+  end
+
+  def split_present_users(value)
+    if value.is_a?(Array) && value.size == 2
+      value.first.to_s + t('log.to') + value.last.to_s
+    else
+      value.to_s
     end
   end
 
   def vote_state_link(vote)
     if vote.present?
-      if vote.open
-        link_to(t('vote.do_close'), close_admin_vote_path(vote),
-                method: :patch)
+      if vote.open?
+        link_to(t('vote.do_close'), close_admin_vote_path(vote), method: :patch)
+      elsif vote.closed?
+        link_to(t('vote.do_open'), open_admin_vote_path(vote), method: :patch, data:
+                { confirm: t('vote.reopen') })
       else
-        link_to(t('vote.do_open'), open_admin_vote_path(vote),
-                method: :patch)
+        link_to(t('vote.do_open'), open_admin_vote_path(vote), method: :patch)
       end
     end
   end
@@ -111,12 +125,6 @@ module VotesHelper
     else
       option.title
     end
-  end
-
-  def user_filter
-    [[Audit.human_attribute_name('User'), 'User'],
-     [Audit.human_attribute_name('VotePost'), 'VotePost'],
-     [Audit.human_attribute_name('Adjustment'), 'Adjustment']]
   end
 
   def vote_filter
@@ -140,7 +148,7 @@ module VotesHelper
     if vote.present?
       content_tag(:div, class: 'headline') do
         content_tag(:h2) do
-          state = vote.open ? t('vote.open') : t('vote.close')
+          state = vote.open? ? t('vote.open') : t('vote.close')
           safe_join([vote.title, ' ', content_tag(:small, state)])
         end
       end
@@ -155,15 +163,23 @@ module VotesHelper
     end
   end
 
-  def vote_stats(vote, adjusted)
+  def vote_stats(vote)
     pcount = vote.vote_posts.sum(:selected)
     ocount = vote.vote_options.sum(:count)
-    result = "#{pcount} / #{adjusted * vote.choices - pcount}"
+    result = "#{pcount} / #{vote.present_users * vote.choices - pcount}"
 
     if pcount != ocount
       result += t('vote.sum_is_wrong')
     end
 
     result
+  end
+
+  def vote_status_str(state)
+    if state.present?
+      Vote.human_attribute_name(state)
+    else
+      t('log.missing')
+    end
   end
 end

--- a/app/models/agenda.rb
+++ b/app/models/agenda.rb
@@ -12,7 +12,7 @@ class Agenda < ActiveRecord::Base
 
   validates :title, :status, presence: true
   validates :index, presence: true, numericality: { greater_than_or_equal_to: 1 }
-  validate :parent_validation, :only_one_current
+  validate :parent_validation, :only_one_current, :no_open_votes
 
   scope :index, -> { order(:sort_index) }
 
@@ -71,6 +71,14 @@ class Agenda < ActiveRecord::Base
   def only_one_current
     if current? && Agenda.current.present? && Agenda.current != self
       errors.add(:status, I18n.t('agenda.too_many_open'))
+    end
+  end
+
+  def no_open_votes
+    if status_changed?(from: CURRENT) && votes.present?
+      unless votes.current.blank?
+        errors.add(:status, I18n.t('agenda.vote_open'))
+      end
     end
   end
 

--- a/app/models/vote_post.rb
+++ b/app/models/vote_post.rb
@@ -61,7 +61,7 @@ class VotePost < ActiveRecord::Base
   end
 
   def vote_open
-    unless vote.present? && vote.open
+    unless vote.present? && vote.open?
       errors.add(:votecode, I18n.t('vote_post.vote_closed'))
     end
   end

--- a/app/services/vote_service.rb
+++ b/app/services/vote_service.rb
@@ -72,4 +72,15 @@ module VoteService
     votecode = Array.new(7) { [*'0'..'9', *'a'..'z'].sample }.join
     (User.with_deleted.any? { |x| x.votecode == votecode }) ? votecode_generator : votecode
   end
+
+  def self.reset(vote)
+    Vote.transaction do
+      vote.update!(present_users: 0, reset: true)
+      vote.vote_posts.destroy_all
+      vote.vote_options.update_all(count: 0)
+      true
+    end
+  rescue
+    false
+  end
 end

--- a/app/views/admin/agendas/_form.html.erb
+++ b/app/views/admin/agendas/_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for [:admin, @agenda] do |f| %>
   <%= f.input :title %>
   <%= f.input :index, as: :integer, input_html: { min: '1'} %>
-  <%= f.input :status, collection: status_collection,
+  <%= f.input :status, collection: agenda_status_collection,
                        input_html: { class: 'select2' }, include_blank: false %>
   <%= f.input :parent_id, collection: Agenda.all, include_hidden: false,
                 input_html: { class: 'select2' }, required: false %>

--- a/app/views/admin/agendas/index.html.erb
+++ b/app/views/admin/agendas/index.html.erb
@@ -23,7 +23,7 @@
       link_to a, edit_admin_agenda_path(a)
     end
     grid.column name: Agenda.human_attribute_name(:status), attribute: 'status', class: 'status' do |a|
-      status_str(a.status)
+      agenda_status_str(a.status)
     end
     grid.column name: t('agenda.change_status'), class: 'state' do |a|
       agenda_state_link(a)

--- a/app/views/admin/agendas/set_closed.js.erb
+++ b/app/views/admin/agendas/set_closed.js.erb
@@ -1,7 +1,7 @@
 <% if @success %>
   $('tr#<%= dom_id(@agenda) %> td.state').html('<%= j agenda_current_link(@agenda) %>');
   $('tr#<%= dom_id(@agenda) %>').removeClass('current');
-  $('tr#<%= dom_id(@agenda) %> td.status').html('<%= j status_str(@agenda.status) %>');
+  $('tr#<%= dom_id(@agenda) %> td.status').html('<%= j agenda_status_str(@agenda.status) %>');
 <% else %>
   $('tr#<%= dom_id(@agenda) %> td.state').html('<%= j agenda_close_link(@agenda) %>');
   $('tr#<%= dom_id(@agenda) %> td.state').append('<br><%= t('agenda.state.short_closed_error') %>');

--- a/app/views/admin/agendas/set_current.js.erb
+++ b/app/views/admin/agendas/set_current.js.erb
@@ -1,7 +1,7 @@
 <% if @success %>
   $('tr#<%= dom_id(@agenda) %> td.state').html('<%= j agenda_close_link(@agenda) %>');
   $('tr#<%= dom_id(@agenda) %>').addClass('current');
-  $('tr#<%= dom_id(@agenda) %> td.status').html('<%= j status_str(@agenda.status) %>');
+  $('tr#<%= dom_id(@agenda) %> td.status').html('<%= j agenda_status_str(@agenda.status) %>');
 <% else %>
   $('tr#<%= dom_id(@agenda) %> td.state').html('<%= j agenda_current_link(@agenda) %>');
   $('tr#<%= dom_id(@agenda) %> td.state').append('<br><%= t('agenda.state.short_current_error') %>');

--- a/app/views/admin/votes/_form.html.erb
+++ b/app/views/admin/votes/_form.html.erb
@@ -2,7 +2,6 @@
   <%= f.input :title %>
   <%= f.association :agenda, collection: Agenda.index, label_method: :to_s  %>
   <%= f.input :choices, as: :integer, input_html: { min: '1'} %>
-  <%= f.input :open, as: :boolean, default: true %>
   <div class="panel panel-default">
     <div class="panel-heading"><%= t('vote.options') %></div>
     <div id="vote_options">

--- a/app/views/admin/votes/index.html.erb
+++ b/app/views/admin/votes/index.html.erb
@@ -13,6 +13,10 @@
   <% end %>
 </div>
 
+<div class="col-md-12 vote status" id="vote-status">
+  <%= render '/admin/votes/status', vote_status_view: @vote_status_view %>
+</div>
+
 <div class="col-md-12">
   <%= grid(@votes_grid) do |grid|
     grid.column name: t('attributes.name'), attribute: 'title' do |v|

--- a/app/views/admin/votes/index.html.erb
+++ b/app/views/admin/votes/index.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title, t('vote.admin_votes')) %>
 <div class="headline">
-  <h2><%= t('vote.admin_votes') %></h2>
+  <h1><%= t('vote.admin_votes') %></h1>
 </div>
 
 <div class="col-md-12">
@@ -23,8 +23,8 @@
         link_to(v.agenda, edit_admin_agenda_path(v.agenda))
       end
     end
-    grid.column name: t('vote.open'), attribute: 'open' do |v|
-      yes_no(v.open)
+    grid.column name: t('vote.status'), attribute: 'status' do |v|
+      vote_status_str(v.status)
     end
     grid.column name: t('vote.open_close') do |v|
       vote_state_link(v)
@@ -34,7 +34,7 @@
     end
     grid.column name: t('remove') do |v|
       link_to(t('remove'), admin_vote_path(v), method: :delete, data:
-              {confirm: t('vote.confirm_remove') + v.title + '?'})
+              { confirm: t('vote.confirm_remove') + v.title + '?'} )
     end
   end -%>
 </div>

--- a/app/views/admin/votes/show.html.erb
+++ b/app/views/admin/votes/show.html.erb
@@ -10,18 +10,26 @@
     </tr>
     <tr>
       <td><%= t('vote.status') %></td>
-      <td><%= @vote_status.vote.open ? t('vote.open') : t('vote.closed') %></td>
+      <td><%= vote_status_str(@vote_status.vote.status) %></td>
     </tr>
     <tr>
       <td><%= Vote.human_attribute_name(:choices) %></td>
       <td><%= @vote_status.vote.choices %></td>
     </tr>
+    <% if @vote_status.vote.closed? %>
+    <tr>
+      <td><%= t('vote.number_of_votes') %></td>
+      <td><%= "#{@vote_status.vote.vote_posts.count} / #{@vote_status.vote.present_users}" %></td>
+    </tr>
+    <% elsif @vote_status.vote.open? %>
     <tr>
       <td><%= t('vote.number_of_votes') %></td>
       <td><%= "#{@vote_status.vote.vote_posts.count} / #{@vote_status.adjusted}" %></td>
     </tr>
+    <% end %>
   </table>
-  <% if @vote_status.vote.open %>
+
+  <% if !@vote_status.vote.closed? %>
     <i><%= t('vote.still_open') %></i>
     <ul class="list">
       <% @vote_status.vote.vote_options.with_deleted.each do |v| %>
@@ -39,7 +47,7 @@
       <% end %>
       <tr>
         <td><i><%= t('vote.sum_votes_blank') %></i></td>
-        <td><i><%= vote_stats(@vote_status.vote, @vote_status.adjusted) %></i></td>
+        <td><i><%= vote_stats(@vote_status.vote) %></i></td>
       </tr>
     </table>
   <% end %>
@@ -62,6 +70,8 @@
     end
     grid.column name: t('log.date'), attribute: 'created_at', filter: false
   end -%>
-<%= link_to t('vote.edit_vote'), edit_admin_vote_path(@vote_status.vote), class: 'btn primary' %>
-<%= link_to t('vote.admin_votes'), admin_votes_path, class: 'btn secondary' %>
+  <%= link_to t('vote.edit_vote'), edit_admin_vote_path(@vote_status.vote), class: 'btn primary' %>
+  <%= link_to t('vote.admin_votes'), admin_votes_path, class: 'btn secondary' %>
+  <%= link_to t('vote.reset'), reset_admin_vote_path(@vote_status.vote), method: :patch,
+              class: 'btn danger pull-right', data: { confirm: t('vote.confirm_reset') } %>
 </div>

--- a/app/views/admin/votes/show.html.erb
+++ b/app/views/admin/votes/show.html.erb
@@ -70,8 +70,11 @@
     end
     grid.column name: t('log.date'), attribute: 'created_at', filter: false
   end -%>
+  <% unless @vote_status.vote.open? %>
   <%= link_to t('vote.edit_vote'), edit_admin_vote_path(@vote_status.vote), class: 'btn primary' %>
-  <%= link_to t('vote.admin_votes'), admin_votes_path, class: 'btn secondary' %>
   <%= link_to t('vote.reset'), reset_admin_vote_path(@vote_status.vote), method: :patch,
               class: 'btn danger pull-right', data: { confirm: t('vote.confirm_reset') } %>
+  <% end %>
+  <%= link_to t('vote.admin_votes'), admin_votes_path, class: 'btn secondary' %>
+  <%= vote_state_link(@vote_status.vote, type: 'btn secondary') %>
 </div>

--- a/app/views/static_pages/_agendas.html.erb
+++ b/app/views/static_pages/_agendas.html.erb
@@ -6,7 +6,7 @@
           <%= agenda %>
         </h4>
         <span class="badge">
-          <%= status_str(agenda.current_status) %>
+          <%= agenda_status_str(agenda.current_status) %>
         </span>
         <p class="list-group-item-text">
           <% if agenda.children.present? %>

--- a/config/locales/models/vote.sv.yml
+++ b/config/locales/models/vote.sv.yml
@@ -8,8 +8,14 @@ sv:
       vote:
         title: Namn
         open: Öppen
+        status: Status
         choices: Max alternativ per röst
         agenda: Dagordning
-
+        future: Framtida
+        current: Aktuell
+        closed: Avslutad
+        agenda_id: Dagordning
+        present_users: Injusterade användare
+        reset: Nollställdes
   vote:
     already_one_open: Det finns redan ett öppet val

--- a/config/locales/views/agenda.sv.yml
+++ b/config/locales/views/agenda.sv.yml
@@ -11,6 +11,7 @@ sv:
     set_current: Gör aktuell
     title: Administrera dagordning
     too_many_open: Nu försöker du ta upp två punkter på dagordningen samtidigt. Så effektiva kan vi inte vara.
+    vote_open: En votering som tillhör denna punkt är fortfarande öppen!
 
     state:
       closed: "%{a} stängdes"

--- a/config/locales/views/votes.sv.yml
+++ b/config/locales/views/votes.sv.yml
@@ -2,7 +2,7 @@ sv:
   vote:
     add_option: Lägg till
     admin_votes: Administrera voteringar
-    already_voted: Du har redan röstat i omröstningen
+    already_voted: Du har redan deltagit i omröstningen
     automatic_refresh: Uppdateras automatiskt var 15 sekund.
     closed: Stängd
     closing_failed: Stängningen misslyckades
@@ -28,8 +28,14 @@ sv:
     results: Resultat
     show_title: Votering
     status: Status
-    still_open: Voteringen är fortfarande öppen. Resultatet kommer att visas här när voteringen har stängts. Följande alternativ finns
+    still_open: Voteringen har ännu inte avslutats. Resultatet kommer att visas här när voteringen har stängts. Följande alternativ finns
     submit: Rösta!
     sum_is_wrong: " Resultatet stämmer inte"
     sum_votes_blank: Σ röster / Σ blanka
     title: Voteringar
+    reopen: "Är du säker på att du vill öppna denna votering igen?\nDetta kommer att påverka statistiken över blanka röster."
+    wrong_agenda: "Voteringen kan enbart öppnas under den valda dagordningspunkten"
+    reset: Nollställ votering
+    reset_ok: Voteringen nollställdes
+    reset_failed: Det gick inte att nollställa voteringen
+    confirm_reset: Är du helt säker på att du vill nollställa voteringen?

--- a/config/locales/views/votes.sv.yml
+++ b/config/locales/views/votes.sv.yml
@@ -4,9 +4,12 @@ sv:
     admin_votes: Administrera voteringar
     already_voted: Du har redan deltagit i omröstningen
     automatic_refresh: Uppdateras automatiskt var 15 sekund.
+    cannot_edit: Voteringen är öppen och kan därmed inte redigeras
+    cannot_reset: Voteringen är öppen och kan därmed inte nollställas
     closed: Stängd
     closing_failed: Stängningen misslyckades
     confirm_remove: "Är du säker på att du vill ta bort "
+    confirm_reset: Är du helt säker på att du vill nollställa voteringen?
     count: Antal
     current: Aktuell omröstning
     current_missing: Ingen omröstning öppen
@@ -23,8 +26,11 @@ sv:
     number_of_votes: Antal röster / antal injusterade
     open: Öppen
     open_close: Öppna/stäng
-    open_failed: Öppningen misslyckades, är ett annat val öppet?
     options: Alternativ
+    reopen: "Är du säker på att du vill öppna denna votering igen?\nDetta kommer att påverka statistiken över blanka röster."
+    reset: Nollställ votering
+    reset_failed: Det gick inte att nollställa voteringen
+    reset_ok: Voteringen nollställdes
     results: Resultat
     show_title: Votering
     status: Status
@@ -33,9 +39,4 @@ sv:
     sum_is_wrong: " Resultatet stämmer inte"
     sum_votes_blank: Σ röster / Σ blanka
     title: Voteringar
-    reopen: "Är du säker på att du vill öppna denna votering igen?\nDetta kommer att påverka statistiken över blanka röster."
     wrong_agenda: "Voteringen kan enbart öppnas under den valda dagordningspunkten"
-    reset: Nollställ votering
-    reset_ok: Voteringen nollställdes
-    reset_failed: Det gick inte att nollställa voteringen
-    confirm_reset: Är du helt säker på att du vill nollställa voteringen?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Fsek::Application.routes.draw do
       resources :votes, path: :voteringar, controller: :votes do
         patch :close, on: :member
         patch :open, on: :member
+        patch :reset, on: :member
         post :refresh, on: :collection
       end
 

--- a/db/migrate/20160322000054_change_to_status_for_vote.rb
+++ b/db/migrate/20160322000054_change_to_status_for_vote.rb
@@ -1,0 +1,6 @@
+class ChangeToStatusForVote < ActiveRecord::Migration
+  def change
+    remove_column :votes, :open, :boolean
+    add_column :votes, :status, :string, null: false, default: 'future'
+  end
+end

--- a/db/migrate/20160322000830_add_present_users_to_vote.rb
+++ b/db/migrate/20160322000830_add_present_users_to_vote.rb
@@ -1,0 +1,5 @@
+class AddPresentUsersToVote < ActiveRecord::Migration
+  def change
+    add_column :votes, :present_users, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160320125754) do
+ActiveRecord::Schema.define(version: 20160322000830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -211,12 +211,13 @@ ActiveRecord::Schema.define(version: 20160320125754) do
 
   create_table "votes", force: :cascade do |t|
     t.string   "title"
-    t.boolean  "open",       default: false, null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.datetime "deleted_at"
-    t.integer  "choices",    default: 1
+    t.integer  "choices",       default: 1
     t.integer  "agenda_id"
+    t.string   "status",        default: "future", null: false
+    t.integer  "present_users", default: 0,        null: false
   end
 
   add_index "votes", ["agenda_id"], name: "index_votes_on_agenda_id", using: :btree

--- a/spec/controllers/admin/adjustments_controller_spec.rb
+++ b/spec/controllers/admin/adjustments_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Admin::AdjustmentsController, type: :controller do
   describe 'GET #index' do
     it 'assigns an agenda' do
       agenda = create(:agenda, status: Agenda::CURRENT)
-      vote = create(:vote, open: true)
+      vote = create(:vote, status: Vote::OPEN, agenda: agenda)
 
       get(:index)
       response.status.should eq(200)

--- a/spec/controllers/admin/agendas_controller_spec.rb
+++ b/spec/controllers/admin/agendas_controller_spec.rb
@@ -134,5 +134,18 @@ RSpec.describe Admin::AgendasController, type: :controller do
       agenda.status.should eq(Agenda::CLOSED)
       Agenda.current.should be_nil
     end
+
+    it 'doesnt work if a associated vote is open' do
+      agenda = create(:agenda, status: Agenda::CURRENT)
+      create(:vote, status: Vote::OPEN, agenda: agenda)
+
+      xhr(:patch, :set_closed, id: agenda.to_param)
+
+      agenda.reload
+      assigns(:agenda).should eq(agenda)
+      assigns(:success).should be_falsey
+      agenda.status.should eq(Agenda::CURRENT)
+      Agenda.current.should eq agenda
+    end
   end
 end

--- a/spec/controllers/admin/votes_controller_spec.rb
+++ b/spec/controllers/admin/votes_controller_spec.rb
@@ -38,6 +38,33 @@ RSpec.describe Admin::VotesController, type: :controller do
       get(:edit, id: vote.to_param)
       assigns(:vote).should eq(vote)
     end
+
+    it 'works if the vote is closed' do
+      vote = create(:vote, status: Vote::CLOSED)
+
+      get(:edit, id: vote.to_param)
+      assigns(:vote).should eq(vote)
+      response.status.should eq(200)
+    end
+
+    it 'works if the vote is future' do
+      vote = create(:vote, status: Vote::FUTURE)
+
+      get(:edit, id: vote.to_param)
+      assigns(:vote).should eq(vote)
+      response.status.should eq(200)
+    end
+
+    it 'fails if the vote is open' do
+      agenda = create(:agenda, status: Agenda::CURRENT)
+      vote = create(:vote, status: Vote::OPEN, agenda: agenda)
+
+      get(:edit, id: vote.to_param)
+
+      assigns(:vote).should eq(vote)
+      flash[:alert].should eq(I18n.t('vote.cannot_edit'))
+      response.should redirect_to(admin_votes_path)
+    end
   end
 
   describe 'GET #new' do
@@ -73,13 +100,36 @@ RSpec.describe Admin::VotesController, type: :controller do
   end
 
   describe 'PATCH #update' do
-    it 'valid parameters' do
+    it 'valid parameters and future vote' do
       vote = create(:vote, title: 'A Bad Title')
 
       patch :update, id: vote.to_param, vote: { title: 'A Good Title' }
       vote.reload
 
+      vote.title.should eq('A Good Title')
       response.should redirect_to(edit_admin_vote_path(vote))
+    end
+
+    it 'valid parameters and closed vote' do
+      vote = create(:vote, title: 'A Bad Title', status: Vote::CLOSED)
+
+      patch :update, id: vote.to_param, vote: { title: 'A Good Title' }
+      vote.reload
+
+      vote.title.should eq('A Good Title')
+      response.should redirect_to(edit_admin_vote_path(vote))
+    end
+
+    it 'fails if the vote is open' do
+      agenda = create(:agenda, status: Agenda::CURRENT)
+      vote = create(:vote, title: 'A Bad Title', status: Vote::OPEN, agenda: agenda)
+
+      patch :update, id: vote.to_param, vote: { title: 'A Good Title' }
+      vote.reload
+
+      vote.title.should eq('A Bad Title')
+      flash[:alert].should eq(I18n.t('vote.cannot_edit'))
+      response.should redirect_to(admin_votes_path)
     end
 
     it 'invalid parameters' do
@@ -119,15 +169,28 @@ RSpec.describe Admin::VotesController, type: :controller do
       vote.open?.should be_truthy
     end
 
-    it 'cannot open the vote' do
+    it 'cannot open the vote if another vote is open' do
       agenda = create(:agenda, status: Agenda::CURRENT)
       create(:vote, status: Vote::OPEN, agenda: agenda)
-      vote = create(:vote, status: Vote::FUTURE)
+      vote = create(:vote, status: Vote::FUTURE, agenda: agenda)
 
       patch(:open, id: vote)
 
       response.should redirect_to(admin_votes_path)
-      flash[:alert].should eq(I18n.t('vote.open_failed'))
+      flash[:alert].should eq(I18n.t('vote.already_one_open'))
+      vote.reload
+      vote.open?.should be_falsey
+    end
+
+    it 'cannot open the vote on the wrong agenda' do
+      create(:agenda, status: Agenda::CURRENT)
+      agenda = create(:agenda, status: Agenda::FUTURE)
+      vote = create(:vote, status: Vote::FUTURE, agenda: agenda)
+
+      patch(:open, id: vote)
+
+      response.should redirect_to(admin_votes_path)
+      flash[:alert].should eq(I18n.t('vote.wrong_agenda'))
       vote.reload
       vote.open?.should be_falsey
     end
@@ -165,6 +228,26 @@ RSpec.describe Admin::VotesController, type: :controller do
       vote.reload
       vote.vote_options.sum(:count).should eq 0
       vote.vote_posts.count.should eq 0
+    end
+
+    it 'fails if the vote is open' do
+      agenda = create(:agenda, status: Agenda::CURRENT)
+      vote = create(:vote, status: Vote::OPEN, agenda: agenda)
+      create(:vote_option, vote: vote, count: 1)
+      create(:vote_option, vote: vote, count: 1)
+      create(:vote_post, vote: vote)
+      create(:vote_post, vote: vote)
+
+      vote.vote_options.sum(:count).should eq 2
+      vote.vote_posts.count.should eq 2
+
+      patch(:reset, id: vote)
+
+      response.should redirect_to(admin_vote_path(vote))
+      flash[:alert].should eq(I18n.t('vote.cannot_reset'))
+      vote.reload
+      vote.vote_options.sum(:count).should eq 2
+      vote.vote_posts.count.should eq 2
     end
   end
 end

--- a/spec/controllers/vote_posts_controller_spec.rb
+++ b/spec/controllers/vote_posts_controller_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe VotePostsController, type: :controller do
 
   describe 'GET #new' do
     it 'sets new vote_post if post is open' do
-      vote = create(:vote, open: true)
+      agenda = create(:agenda, status: Agenda::CURRENT)
+      vote = create(:vote, status: Vote::OPEN, agenda: agenda)
 
       get(:new, vote_id: vote)
 
@@ -22,7 +23,17 @@ RSpec.describe VotePostsController, type: :controller do
     end
 
     it 'redirects if vote is closed' do
-      vote = create(:vote, open: false)
+      vote = create(:vote, status: Vote::CLOSED)
+
+      get(:new, vote_id: vote.to_param)
+
+      assigns(:vote).should eq(vote)
+      response.should redirect_to(votes_path)
+      flash[:alert].should eq(I18n.t('vote.is_closed'))
+    end
+
+    it 'redirects if vote is future' do
+      vote = create(:vote, status: Vote::FUTURE)
 
       get(:new, vote_id: vote.to_param)
 
@@ -34,8 +45,9 @@ RSpec.describe VotePostsController, type: :controller do
 
   describe 'POST #create' do
     it 'valid parameters' do
+      agenda = create(:agenda, status: Agenda::CURRENT)
       user.update!(presence: true, votecode: 'abcd123')
-      vote = create(:vote, :with_options, open: true)
+      vote = create(:vote, :with_options, status: Vote::OPEN, agenda: agenda)
       attributes = { votecode: 'abcd123',
                      vote_option_ids: [vote.vote_options.first.id] }
 
@@ -48,7 +60,8 @@ RSpec.describe VotePostsController, type: :controller do
 
     it 'invalid parameters' do
       user.update!(presence: true, votecode: 'abcd123')
-      vote = create(:vote, :with_options, open: true)
+      agenda = create(:agenda, status: Agenda::CURRENT)
+      vote = create(:vote, :with_options, status: Vote::OPEN, agenda: agenda)
       attributes = { votecode: 'falseyfalsey',
                      vote_option_ids: [vote.vote_options.first.id] }
 

--- a/spec/factories/votes.rb
+++ b/spec/factories/votes.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :vote do
     title
-    open false
+    status Vote::FUTURE
     choices 1
 
     trait :with_options do

--- a/spec/features/votes_spec.rb
+++ b/spec/features/votes_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.feature 'votes' do
   describe 'voting' do
     it 'manages to create new vote_post' do
-      vote = create(:vote, :with_options)
+      agenda = create(:agenda, status: Agenda::CURRENT)
+      vote = create(:vote, :with_options, agenda: agenda)
       user = create(:user, presence: true, votecode: 'abcd123')
-      vote.update!(open: true)
+      vote.update!(status: Vote::OPEN)
       LoginPage.new.visit_page.login(user)
 
       page.visit votes_path

--- a/spec/models/agenda_spec.rb
+++ b/spec/models/agenda_spec.rb
@@ -43,5 +43,14 @@ RSpec.describe Agenda, type: :model do
 
       agenda1.errors[:parent_id].should include I18n.t('agenda.recursion')
     end
+
+    it 'can not close if a associated vote is open' do
+      agenda = create(:agenda, status: Agenda::CURRENT)
+      create(:vote, status: Vote::OPEN, agenda: agenda)
+      agenda.status = Agenda::CLOSED
+      agenda.valid?
+
+      agenda.errors[:status].should include I18n.t('agenda.vote_open')
+    end
   end
 end

--- a/spec/models/vote_post_spec.rb
+++ b/spec/models/vote_post_spec.rb
@@ -20,14 +20,16 @@ RSpec.describe VotePost, type: :model do
   describe 'validations' do
     context 'user' do
       it 'is present' do
-        create(:vote, open: true)
+        agenda = create(:agenda, status: Agenda::CURRENT)
+        create(:vote, status: Vote::OPEN, agenda: agenda)
         vote_post = build(:vote_post)
 
         vote_post.should validate_presence_of(:user_id)
       end
 
       it 'is unique to vote' do
-        vote = create(:vote, open: true)
+        agenda = create(:agenda, status: Agenda::CURRENT)
+        vote = create(:vote, status: Vote::OPEN, agenda: agenda)
         vote_post = build(:vote_post, user: user, vote: vote)
         vote_post.should validate_uniqueness_of(:user_id).scoped_to(:vote_id).with_message(I18n.t('vote_post.already_voted'))
       end
@@ -65,7 +67,8 @@ RSpec.describe VotePost, type: :model do
       end
 
       it 'is open' do
-        vote = build(:vote, open: true)
+        agenda = create(:agenda, status: Agenda::CURRENT)
+        vote = build(:vote, status: Vote::OPEN, agenda: agenda)
         vote_post = build(:vote_post, vote: vote)
         vote_post.valid?
 
@@ -73,7 +76,7 @@ RSpec.describe VotePost, type: :model do
       end
 
       it 'is closed' do
-        vote = build(:vote, open: false)
+        vote = build(:vote, status: Vote::CLOSED)
         vote_post = build(:vote_post, vote: vote)
         vote_post.valid?
 

--- a/spec/models/vote_spec.rb
+++ b/spec/models/vote_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Vote, type: :model do
+  describe 'validations' do
+    it 'can only have one open vote' do
+      agenda = create(:agenda, status: Agenda::CURRENT)
+      create(:vote, status: Vote::OPEN, agenda: agenda)
+      vote = build(:vote, status: Vote::OPEN)
+      vote.valid?
+
+      vote.errors[:status].should include I18n.t('vote.already_one_open')
+    end
+
+    it 'updates present count on closing vote' do
+      create(:user, presence: true)
+      create(:user, presence: true)
+      agenda = create(:agenda, status: Agenda::CURRENT)
+      vote = create(:vote, status: Vote::OPEN, agenda: agenda)
+      vote.present_users.should equal 0
+
+      vote.update(status: Vote::CLOSED)
+      vote.present_users.should equal 2
+    end
+
+    it 'does not update present count on opening vote' do
+      create(:user, presence: true)
+      create(:user, presence: true)
+      agenda = create(:agenda, status: Agenda::CURRENT)
+      vote = create(:vote, status: Vote::FUTURE, agenda: agenda)
+      vote.present_users.should equal 0
+
+      vote.update(status: Vote::OPEN)
+      vote.present_users.should equal 0
+    end
+  end
+end

--- a/spec/view_objects/vote_status_view_spec.rb
+++ b/spec/view_objects/vote_status_view_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe VoteStatusView do
     it 'sets current' do
       agenda = create(:agenda, status: Agenda::CURRENT)
       create(:agenda, status: Agenda::CLOSED)
-      vote = create(:vote, open: true)
-      create(:vote, open: false)
+      vote = create(:vote, status: Vote::OPEN, agenda: agenda)
+      create(:vote, status: Vote::CLOSED)
       create(:user, presence: true)
       create(:user, presence: true)
       create(:user, presence: true)


### PR DESCRIPTION
Changing `:open` to `:status` for `Vote`
Only allows votes to be opened if they belong to the current agenda
Prevents agendas from closing if they have associated votes that are open
Makes it possible to reset votes