### PR TITLE
Soft deletion fixes

### DIFF
--- a/app/controllers/admin/agendas_controller.rb
+++ b/app/controllers/admin/agendas_controller.rb
@@ -36,8 +36,13 @@ class Admin::AgendasController < Admin::BaseController
   def destroy
     @agenda = Agenda.find(params[:id])
 
-    @agenda.destroy!
-    redirect_to admin_agendas_path, notice: alert_destroy(Agenda)
+    if @agenda.destroy
+      flash[:notice] = t('agenda.deleted_ok')
+    else
+      flash[:alert] = @agenda.errors. full_messages_for(:destroy).to_sentence
+    end
+
+    redirect_to admin_agendas_path
   end
 
   def set_current

--- a/app/controllers/admin/vote_users_controller.rb
+++ b/app/controllers/admin/vote_users_controller.rb
@@ -9,8 +9,11 @@ class Admin::VoteUsersController < Admin::BaseController
   def show
     @user = User.find(params[:id])
     @votes = Vote.with_deleted
-    @audit_grid = initialize_grid(Audit.where(user_id: @user.id), include: :updater, name: 'g')
     @adjustments = @user.adjustments.rank(:row_order)
+    @audit_grid = initialize_grid(Audit.where(user_id: @user.id),
+                                  include: :updater,
+                                  order: 'created_at',
+                                  order_direction: 'desc')
   end
 
   def attendance_list

--- a/app/helpers/votes_helper.rb
+++ b/app/helpers/votes_helper.rb
@@ -87,8 +87,10 @@ module VotesHelper
   end
 
   def agenda_log_str(value)
-    if value.present?
-      '§' + Agenda.find(value).order
+    agenda = Agenda.with_deleted.find_by_id(value)
+
+    if agenda.present?
+      agenda.to_s
     else
       t('log.missing')
     end

--- a/app/views/admin/votes/index.html.erb
+++ b/app/views/admin/votes/index.html.erb
@@ -6,7 +6,7 @@
 <div class="col-md-12">
   <%= link_to t('vote.new_vote'), new_admin_vote_path, class: 'btn primary' %>
   <% if can? :manage, User %>
-    <%= link_to t('user.manage'), admin_vote_users_path, class: 'btn secondary' %>
+    <%= link_to t('vote_user.manage'), admin_vote_users_path, class: 'btn secondary' %>
   <% end %>
   <% if can? :manage, Agenda %>
     <%= link_to t('agenda.manage'), admin_agendas_path, class: 'btn secondary' %>

--- a/app/views/notices/_notice.html.erb
+++ b/app/views/notices/_notice.html.erb
@@ -2,7 +2,5 @@
   <h3><%= notice.title %></h3>
 </div>
 <div class="search-blocks row">
-  <div class="col-md-12">
-    <%= simple_format(notice.description) %>
-  </div>
+  <%= simple_format(notice.description) %>
 </div>

--- a/app/views/votes/index.html.erb
+++ b/app/views/votes/index.html.erb
@@ -26,12 +26,14 @@
       <%= @vote_status.agenda.to_s %>
     </h5>
 
-    <%= models_name(Vote) %>
-    <ul class="list">
-      <% @vote_status.agenda.votes.each do |vote| %>
-        <li><%= vote.title %></li>
-      <% end %>
-    </ul>
+    <% if @vote_status.agenda.votes.present? %>
+      <%= models_name(Vote) %>
+      <ul class="list">
+        <% @vote_status.agenda.votes.order(:id).each do |vote| %>
+          <li><%= vote.title %></li>
+        <% end %>
+      </ul>
+    <% end %>
   <% end %>
 </div>
 

--- a/config/locales/views/agenda.sv.yml
+++ b/config/locales/views/agenda.sv.yml
@@ -2,8 +2,11 @@ sv:
   agenda:
     change_status: Ändra status
     close: Stäng
-    current: Aktuell dagordning
+    current: Aktuell dagordningspunkt
+    deleted: " [RADERAD]"
+    deleted_ok: Dagordningspunkten har raderas
     edit: Redigera punkt
+    error_deleting: Öppna punkter kan ej raderas
     manage: Hantera dagordning
     name: Dagordning
     new: Ny punkt

--- a/config/locales/views/votes.sv.yml
+++ b/config/locales/views/votes.sv.yml
@@ -22,7 +22,7 @@ sv:
     made_open: Öppnades
     manage: Hantera voteringar
     new_vote: Ny votering
-    no_votes_open: "Just nu finns det tyvärr inga voteringar som är öppna :("
+    no_votes_open: "Just nu finns det tyvärr ingen votering som är öppen."
     number_of_votes: Antal röster / antal injusterade
     open: Öppen
     open_close: Öppna/stäng


### PR DESCRIPTION
**Soft deletion fixes**:
- Prevents open agendas from being deleted
- Displays the title of deleted agendas in the audit logs + adjustments table instead of blank
- Fixes an error that broke admin/vote_users/show if an agenda was deleted


**Small view fixes**