### PR TITLE
Force SSL with env variable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = ENV['FORCE_SSL'] || false
 
   # Set to :debug to see everything in the log.
   config.log_level = :warn


### PR DESCRIPTION
To allow changing the force on Heroku
Good for running staging apps without SSL