### PR TITLE
Assure blank votes are supported

### DIFF
--- a/spec/system/votes_spec.rb
+++ b/spec/system/votes_spec.rb
@@ -24,4 +24,25 @@ RSpec.describe 'votes' do
     expect(page).to have_css('div.alert')
     expect(find('div.alert').text).to include(t('vote_posts.create.success'))
   end
+
+  it 'manages to create new blank vote_post', js: true do
+    sub_item = create(:sub_item, status: :current)
+    vote = create(:vote, :with_options, sub_item: sub_item)
+    user = create(:user, presence: true, votecode: 'abcd123')
+    vote.update!(status: :open)
+    LoginPage.new.visit_page.login(user)
+
+    page.visit(votes_path)
+
+    first(:linkhref, vote_vote_posts_path(vote)).click
+
+    fill_in('vote_post[votecode]', with: 'abcd123')
+
+    accept_confirm do
+      find('#vote_post_submit').click
+    end
+
+    expect(page).to have_css('div.alert')
+    expect(find('div.alert').text).to include(t('vote_posts.create.success'))
+  end
 end


### PR DESCRIPTION
Adds a spec for #298, it was already fixed in an earlier PR where I removed the `required: true` tag.

We did not use HTML5-validations before, therefore allowing an empty field to be submitted even when `required: true` was set.

